### PR TITLE
Changes the Conditional to Check for UAC Flags as a String

### DIFF
--- a/Python/PwnedCheck.py
+++ b/Python/PwnedCheck.py
@@ -124,7 +124,7 @@ while (loop=='y') or (loop=='Y'):
                     email = entry["mail"]
                     if verbose:
                         print(uac)
-                    if uac != "514":
+                    if uac != "514": #Flags to Check Against are typed as a string because entry["userAccountControl"] returns a string.
                         pwnwriter.writerow([username, email, outputname])
                         if verbose:
                             print("hit; username:", username, "was a victim of the", outputname, "breach")       

--- a/Python/PwnedCheck.py
+++ b/Python/PwnedCheck.py
@@ -124,7 +124,7 @@ while (loop=='y') or (loop=='Y'):
                     email = entry["mail"]
                     if verbose:
                         print(uac)
-                    if uac != 514:
+                    if uac != "514":
                         pwnwriter.writerow([username, email, outputname])
                         if verbose:
                             print("hit; username:", username, "was a victim of the", outputname, "breach")       


### PR DESCRIPTION
After further testing, it appears that the attribute is returned as a string within the entry object(s).

As of now, this will export any existing AD account to the CSV, rather than only exporting AD accounts that are Enabled.

Note: This Script only Checks for UAC of 514, additional UAC flags are possible, and modification is pretty simple.